### PR TITLE
Add option to serve non-root applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Additional parameters:
 * `--quiet` - suppress logging
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--port=8081` - open with port
+* `--base=BASEPATH` - require all requests to be prefixed by given virtual path
 * `--proxy=http://localhost:8080` - proxy a running server
 * `--only-exts=""` - watch only files with the specified extensions
 * `--ignore-exts=""` - exclude files with the specified extensions

--- a/index.js
+++ b/index.js
@@ -123,8 +123,8 @@ LiveServer.start = function (options) {
   var openPath = (options.open === undefined || options.open === true) ?
     "" : ((options.open === null || options.open === false) ? null : options.open);
 
-  if (options.base) {
-    openPath += options.base;
+  if (base) {
+    openPath += base;
   }
   if (options.noBrowser) openPath = null; // Backwards compatibility with 0.7.0
   var html5mode = fs.existsSync(root + "/200.html")

--- a/index.js
+++ b/index.js
@@ -122,6 +122,10 @@ LiveServer.start = function (options) {
   var logLevel = options.logLevel === undefined ? 2 : options.logLevel;
   var openPath = (options.open === undefined || options.open === true) ?
     "" : ((options.open === null || options.open === false) ? null : options.open);
+
+  if (options.base) {
+    openPath += options.base;
+  }
   if (options.noBrowser) openPath = null; // Backwards compatibility with 0.7.0
   var html5mode = fs.existsSync(root + "/200.html")
   if (html5mode) {

--- a/jspm-server.js
+++ b/jspm-server.js
@@ -34,6 +34,10 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 		opts.open = path;
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--base=") > -1) {
+		opts.base = arg.substring(7);
+		process.argv.splice(i, 1);
+	}
 	else if (arg.indexOf("--only-exts=") > -1) {
 		var extensions = []
 		var extArgs = arg.substring(12);


### PR DESCRIPTION
Same implementation of this live-server branch:  https://github.com/tapio/live-server/tree/base-url
- Adds support for JSPM server to serve apps at a specified BASE path
- Opens browser at BASE path when option is present
